### PR TITLE
Fix kwargs check in controlGripper

### DIFF
--- a/environment/utilities.py
+++ b/environment/utilities.py
@@ -52,7 +52,7 @@ def setup_sisbot(p, robotID, gripper_type):
             raise NotImplementedError(
                 "controlGripper does not support \"{}\" control mode".format(controlMode))
         # check if there
-        if len(kwargs) is not 0:
+        if len(kwargs) != 0:
             raise KeyError("No keys {} in controlGripper".format(
                 ", ".join(kwargs.keys())))
 
@@ -135,7 +135,7 @@ def setup_sisbot_force(p, robotID, gripper_type):
             raise NotImplementedError(
                 "controlGripper does not support \"{}\" control mode".format(controlMode))
         # check if there
-        if len(kwargs) is not 0:
+        if len(kwargs) != 0:
             raise KeyError("No keys {} in controlGripper".format(
                 ", ".join(kwargs.keys())))
 


### PR DESCRIPTION
## Summary
- correct a Python identity comparison typo in `utilities.py`

## Testing
- `python -m py_compile environment/utilities.py`
- `python -m py_compile simulation.py`
- `python -m py_compile network/run_offline.py`


------
https://chatgpt.com/codex/tasks/task_e_68526ad8dea0832881d49e52e3580df7